### PR TITLE
Avoid the need of jsx-loader as global dependency.

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -1,1 +1,1 @@
-module.exports = require('jsx-loader!./src/InfiniteAnyHeight.jsx')
+module.exports = require('../jsx-loader!./src/InfiniteAnyHeight.jsx')


### PR DESCRIPTION
I didn't have jsx-loader installed as global package and this were not working.
Now with this tiny modification is working great.

Thank you very much for this module!