### PR TITLE
Webpack 2.0 - Compatibility

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -1,1 +1,1 @@
-module.exports = require('babel?presets[]=react&presets[]=es2015!./src/InfiniteAnyHeight.jsx')
+module.exports = require('babel-loader?presets[]=react&presets[]=es2015!./src/InfiniteAnyHeight.jsx')


### PR DESCRIPTION
Addresses: BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'babel-loader' instead of 'babel',
                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed