### PR TITLE
Reference PropTypes instead of React.PropTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,11 @@ export default class InfiniteAnyHeight extends Component {
   static displayName = 'InfiniteAnyHeight';
 
   static propTypes = {
-    heights: React.PropTypes.array,
-    heightsUpdateCallback: React.PropTypes.func,
-    list: React.PropTypes.node,
-    scrollContainer: React.PropTypes.object,
-    useWindowAsScrollContainer: React.PropTypes.bool
+    heights: PropTypes.array,
+    heightsUpdateCallback: PropTypes.func,
+    list: PropTypes.node,
+    scrollContainer: PropTypes.object,
+    useWindowAsScrollContainer: PropTypes.bool
   };
 
   static defaultProps = {


### PR DESCRIPTION
I was getting a "Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead" which pointed to this file. Updating the reference should make it go away.